### PR TITLE
Update foundation.util.triggers.js

### DIFF
--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -76,7 +76,6 @@ function checkListeners() {
   eventsListener();
   resizeListener();
   scrollListener();
-  mutateListener();
   closemeListener();
 }
 
@@ -156,17 +155,6 @@ function scrollListener(debounce){
   }
 }
 
-function mutateListener(debounce) {
-    let $nodes = $('[data-mutate]');
-    if ($nodes.length && MutationObserver){
-			//trigger all listening elements and signal a mutate event
-      //no IE 9 or 10
-			$nodes.each(function () {
-			  $(this).triggerHandler('mutateme.zf.trigger');
-			});
-    }
- }
-
 function eventsListener() {
   if(!MutationObserver){ return false; }
   let nodes = document.querySelectorAll('[data-resize], [data-scroll], [data-mutate]');
@@ -220,38 +208,3 @@ Foundation.IHearYou = checkListeners;
 // Foundation.IFeelYou = closemeListener;
 
 }(jQuery);
-
-// function domMutationObserver(debounce) {
-//   // !!! This is coming soon and needs more work; not active  !!! //
-//   var timer,
-//   nodes = document.querySelectorAll('[data-mutate]');
-//   //
-//   if (nodes.length) {
-//     // var MutationObserver = (function () {
-//     //   var prefixes = ['WebKit', 'Moz', 'O', 'Ms', ''];
-//     //   for (var i=0; i < prefixes.length; i++) {
-//     //     if (prefixes[i] + 'MutationObserver' in window) {
-//     //       return window[prefixes[i] + 'MutationObserver'];
-//     //     }
-//     //   }
-//     //   return false;
-//     // }());
-//
-//
-//     //for the body, we need to listen for all changes effecting the style and class attributes
-//     var bodyObserver = new MutationObserver(bodyMutation);
-//     bodyObserver.observe(document.body, { attributes: true, childList: true, characterData: false, subtree:true, attributeFilter:["style", "class"]});
-//
-//
-//     //body callback
-//     function bodyMutation(mutate) {
-//       //trigger all listening elements and signal a mutation event
-//       if (timer) { clearTimeout(timer); }
-//
-//       timer = setTimeout(function() {
-//         bodyObserver.disconnect();
-//         $('[data-mutate]').attr('data-events',"mutate");
-//       }, debounce || 150);
-//     }
-//   }
-// }


### PR DESCRIPTION
This is not used, eventsListener() is the "attacher" of mutate now, not mutateListener(), so removing and removing the call, along with some comments from the past that I not longer need.